### PR TITLE
custom query in live stream for display additional attributes

### DIFF
--- a/app/views/searchjoy/searches/recent.html.erb
+++ b/app/views/searchjoy/searches/recent.html.erb
@@ -3,7 +3,8 @@
     <td style="width: 15%;">
       <%= link_to search.search_type, searchjoy.overview_searches_path(search_type: search.search_type), class: "type-link type-link-#{@search_types.index(search.search_type)}" %>
     </td>
-    <td><%= search.query %></td>
+    <td><%= Searchjoy.recent_query ? Searchjoy.recent_query.call(search) : search.query %></td>
+
     <td style="width: 35%; color: #5cb85c;">
       <% if search.converted_at %>
         <strong>✓</strong>

--- a/lib/searchjoy.rb
+++ b/lib/searchjoy.rb
@@ -19,6 +19,7 @@ module Searchjoy
 
   # conversion name
   mattr_accessor :conversion_name
+  mattr_accessor :recent_query
 end
 
 if defined?(Searchkick)


### PR DESCRIPTION
Hey Andrew,

i add a little hotfix with the same behaviour for customizing the search query in live stream as for conversion name.

```
Searchjoy.recent_query = proc{|model| "#{model.query} | #{model.query_city" }
```

Many thanks for both awesome gems **searchkick** and **searchjoy**
René
