### PR TITLE
Support modified queries

### DIFF
--- a/lib/searchjoy/track.rb
+++ b/lib/searchjoy/track.rb
@@ -1,13 +1,14 @@
 module Searchjoy
   module Track
-    def search_with_track(term, options = {})
-      results = search_without_track(term, options)
+    def search_with_track(term, options = {}, &block)
+      results = search_without_track(term, options) do |body|
+        block.call(body) if block
+      end
 
       if options[:track]
         attributes = options[:track] == true ? {} : options[:track]
         results.search = Searchjoy::Search.create({search_type: name, query: term, results_count: results.total_count}.merge(attributes))
       end
-
       results
     end
   end


### PR DESCRIPTION
Noticed that including the searchjoy gem breaks cases where the generated query is modified using the below syntax:

```
products =
  Product.search "apples" do |body|
    body[:query] = {match_all: {}}
  end
```

Updated to support modified queries.