### PR TITLE
Includes convertable association to avoid N+1 query in recent searches

### DIFF
--- a/app/controllers/searchjoy/searches_controller.rb
+++ b/app/controllers/searchjoy/searches_controller.rb
@@ -32,7 +32,7 @@ module Searchjoy
     end
 
     def recent
-      @searches = Searchjoy::Search.order("created_at desc").limit(50)
+      @searches = Searchjoy::Search.includes(:convertable).order("created_at desc").limit(50)
       render layout: false
     end
 


### PR DESCRIPTION
I've noticed this in my logs, since this request is pooling when Searchjoy is open, I think it is good to take care of this N+1 query.

Before:
<img width="1087" alt="screenshot 2016-03-15 15 41 56" src="https://cloud.githubusercontent.com/assets/3727827/13790413/149a75ba-eac7-11e5-827d-76e2c2f4a775.png">

After:
<img width="1096" alt="screenshot 2016-03-15 15 41 41" src="https://cloud.githubusercontent.com/assets/3727827/13790417/177f8284-eac7-11e5-802f-c181d5600bc2.png">

Let me know your thoughts on this.
