### PR TITLE
Use before_action instead of deprecated before_filter

### DIFF
--- a/app/controllers/searchjoy/searches_controller.rb
+++ b/app/controllers/searchjoy/searches_controller.rb
@@ -4,11 +4,11 @@ module Searchjoy
 
     http_basic_authenticate_with name: ENV["SEARCHJOY_USERNAME"], password: ENV["SEARCHJOY_PASSWORD"] if ENV["SEARCHJOY_PASSWORD"]
 
-    before_filter :set_time_zone
-    before_filter :set_search_types
-    before_filter :set_search_type, only: [:index, :overview]
-    before_filter :set_time_range, only: [:index, :overview]
-    before_filter :set_searches, only: [:index, :overview]
+    before_action :set_time_zone
+    before_action :set_search_types
+    before_action :set_search_type, only: [:index, :overview]
+    before_action :set_time_range, only: [:index, :overview]
+    before_action :set_searches, only: [:index, :overview]
 
     def index
       if params[:sort] == "conversion_rate"


### PR DESCRIPTION
I'm getting a deprecation warning when using this with Rails 5. 
Easy fix, just replace `before_filter` with `before_action`. 

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <class:SearchesController> at /Users/Dwight/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/searchjoy-2a96e39df747/app/controllers/searchjoy/searches_controller.rb:7)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <class:SearchesController> at /Users/Dwight/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/searchjoy-2a96e39df747/app/controllers/searchjoy/searches_controller.rb:8)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <class:SearchesController> at /Users/Dwight/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/searchjoy-2a96e39df747/app/controllers/searchjoy/searches_controller.rb:9)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <class:SearchesController> at /Users/Dwight/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/searchjoy-2a96e39df747/app/controllers/searchjoy/searches_controller.rb:10)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <class:SearchesController> at /Users/Dwight/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/searchjoy-2a96e39df747/app/controllers/searchjoy/searches_controller.rb:11)
```