### PR TITLE
Make convertable association optional

### DIFF
--- a/app/models/searchjoy/search.rb
+++ b/app/models/searchjoy/search.rb
@@ -1,6 +1,6 @@
 module Searchjoy
   class Search < ActiveRecord::Base
-    belongs_to :convertable, polymorphic: true
+    belongs_to :convertable, polymorphic: true, optional: true
 
     # the devise way
     if (Rails::VERSION::MAJOR == 3 && !defined?(ActionController::StrongParameters)) || defined?(ActiveModel::MassAssignmentSecurity)

--- a/app/models/searchjoy/search.rb
+++ b/app/models/searchjoy/search.rb
@@ -1,6 +1,10 @@
 module Searchjoy
   class Search < ActiveRecord::Base
-    belongs_to :convertable, polymorphic: true, optional: true
+    if Rails::VERSION::MAJOR == 5
+      belongs_to :convertable, polymorphic: true, optional: true
+    else
+      belongs_to :convertable, polymorphic: true
+    end
 
     # the devise way
     if (Rails::VERSION::MAJOR == 3 && !defined?(ActionController::StrongParameters)) || defined?(ActiveModel::MassAssignmentSecurity)


### PR DESCRIPTION
In Rails 5 the `belongs_to` association has become required by default.

Because the `convertable` association is optional we'll need to mark it as such as to not cause validation errors.

As versions of Rails before 5 won't recognise the `optional` option I've scoped the definition to Rails 5.