### PR TITLE
Truncate queries longer than DB column size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1 (unreleased)
 
 - Improved dashboard labels
+- Truncate queries longer than DB column size
 
 ## 1.0.0 (2022-05-10)
 

--- a/app/models/searchjoy/search.rb
+++ b/app/models/searchjoy/search.rb
@@ -6,6 +6,7 @@ module Searchjoy
     belongs_to :user, optional: true
     has_many :conversions
 
+    before_validation :truncate_query
     before_save :set_normalized_query
 
     def convert(convertable = nil)
@@ -40,6 +41,11 @@ module Searchjoy
     end
 
     protected
+
+    def truncate_query
+      return unless ( max_length = self.class.type_for_attribute(:query).limit ).present?
+      self.query = query.truncate( max_length )
+    end
 
     def set_normalized_query
       self.normalized_query = query.downcase if query


### PR DESCRIPTION
`ActiveRecord::ValueTooLong: Mysql2::Error: Data too long for column 'query' at row 1` will happen for queries that exceed DB column size (255 chars in mysql).

I don't see any point in storing/analyzing queries longer than that, so let's just truncate them.