### PR TITLE
Tweak track method to simplify connection handler wrapping

### DIFF
--- a/lib/searchjoy/track.rb
+++ b/lib/searchjoy/track.rb
@@ -18,8 +18,21 @@ module Searchjoy
               "All Indices"
             end
 
-          results.search = Searchjoy::Search.create({search_type: search_type, query: term, results_count: results.total_count}.merge(attributes))
+          results.search = create_search({search_type: search_type, query: term, results_count: results.total_count}.merge(attributes))
         end
+      end
+      
+      # pull this out to allow override for multi_db support. ie:
+      # module ReaderWrapper
+      #   def create_search(hash)
+      #     ActiveRecord::Base.connected_to(role: :writing) do
+      #       super
+      #     end
+      #   end
+      # end
+      # Searchjoy::Track::Query.prepend(ReaderWrapper)
+      def create_search(hash)
+        Searchjoy::Search.create(hash)
       end
 
       def execute


### PR DESCRIPTION
A small extract to simplify wrapping the search tracking create operation for multi DB reader/writer support. Thought was to reduce the risk of future changes breaking the monkey patch while also not introducing any 'new' concepts in to the gem.

I know there are a few other ways that gems handle this like [passing a connection builder like counter_culture](https://github.com/magnusvk/counter_culture#fix-counter-cache-using-a-replica-database)

If you have a different preference on support/handling for multi db support, please let me know, I'm happy to adjust the PR!