### PR TITLE
Little dashboard improvement

### DIFF
--- a/app/assets/stylesheets/searchjoy/application.css
+++ b/app/assets/stylesheets/searchjoy/application.css
@@ -26,7 +26,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   margin-bottom: 20px;
-  table-layout: auto;
 }
 
 th {

--- a/app/assets/stylesheets/searchjoy/application.css
+++ b/app/assets/stylesheets/searchjoy/application.css
@@ -26,6 +26,7 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   margin-bottom: 20px;
+  table-layout: auto;
 }
 
 th {
@@ -57,6 +58,7 @@ table td, table th {
 
 td {
   border-top: solid 1px #ddd;
+  word-wrap: break-word;
 }
 
 .text-muted {
@@ -79,6 +81,7 @@ a.type-link {
   color: #fff;
   padding: 8px;
   border-radius: 4px;
+  text-wrap: nowrap;
 }
 
 a.type-link:hover {


### PR DESCRIPTION
There's some annoying issues with how text wraps on the dashboard. The `search_type` wraps when there's spaces in the constant (ex. `ItemPage`) and if the query is very long it doesn't wrap and stretches the table making it difficult to read. 

Before
![image](https://github.com/ankane/searchjoy/assets/49426163/80d9c03a-f814-4a6f-8139-63938afd8d3b)

After
![image](https://github.com/ankane/searchjoy/assets/49426163/2d48f25a-51f9-463c-83d9-c6d08ad48238)
