### PR TITLE
Take account of timezone offset for Litepicker

### DIFF
--- a/app/views/layouts/searchjoy/application.html.erb
+++ b/app/views/layouts/searchjoy/application.html.erb
@@ -51,9 +51,16 @@
                   onSelect: function(date1, date2) {
                     var currentParams = new URLSearchParams(window.location.search);
                     var params = new URLSearchParams();
+
+                    var tzoffset1 = date1.getTimezoneOffset() * 60000;
+                    var startDateParam = new Date((date1 - tzoffset1)).toISOString().slice(0, 10);
+
+                    var tzoffset2 = date2.getTimezoneOffset() * 60000;
+                    var endDateParam = new Date((date2 - tzoffset2)).toISOString().slice(0, 10);
+
+                    params.set('start_date', startDateParam);
+                    params.set('end_date', endDateParam);
                     params.set('search_type', currentParams.get('search_type'));
-                    params.set('start_date', date1.toISOString().slice(0, 10));
-                    params.set('end_date', date2.toISOString().slice(0, 10));
                     window.location.href = window.location.pathname + "?" + params.toString();
                   }
                 });


### PR DESCRIPTION
When selecting dates in the datepicker, I'm facing the following issue: the values that end up being submitted under `start_date/end_date` are one day older than expected.

The reason is that `toISOString()` returns a `Date` instance whose timezone is [always UTC][mdn_docs_toisostring]. Here is what I observe when console logging the values of `date1` and `date1.toISOString()`:

<img width="511" alt="Screenshot 2024-11-19 at 18 01 48" src="https://github.com/user-attachments/assets/612f1c5e-882c-4310-83d0-01c9893bd27e">

This can be fixed by slightly altering the `onSelect` function in `application.html.erb` so that we compute offset-aware values for both `start_date` and `end_date`.

The new implementation takes inspiration from [this SO answer][so_answer]: the idea is to retrieve the offset using `getTimezoneOffset()`, convert it to milliseconds, and then subtract it from the `Date` instance.

[mdn_docs_toisostring]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
[so_answer]: https://stackoverflow.com/a/28149561